### PR TITLE
Metaprogram the integration tests 

### DIFF
--- a/test/integration/vm_translator_test.rb
+++ b/test/integration/vm_translator_test.rb
@@ -1,39 +1,14 @@
 require "test_helper"
 
 class VMTranslatorIntegrationTest < Minitest::Test
-  def test_integration_test
-    assembly_code = `bin/vm-translator examples/Push.vm`
-    expected = File.read("test/fixtures/Push.asm")
-    assert_equal(expected, assembly_code)
-  end
+  Dir.glob("examples/**").each do |file_path|
+    file_name = /examples\/(.*).vm/.match(file_path)[1]
+    test_name = "test_integration_#{file_name}"
 
-  def test_integration_test_simple_add
-    assembly_code = `bin/vm-translator examples/SimpleAdd.vm`
-    expected = File.read("test/fixtures/SimpleAdd.asm")
-    assert_equal(expected, assembly_code)
-  end
-
-  def test_integration_test_simple_eq
-    assembly_code = `bin/vm-translator examples/SimpleEq.vm`
-    expected = File.read("test/fixtures/SimpleEq.asm")
-    assert_equal(expected, assembly_code)
-  end
-
-  def test_integration_test_stack_test
-    assembly_code = `bin/vm-translator examples/StackTest.vm`
-    expected = File.read("test/fixtures/StackTest.asm")
-    assert_equal(expected, assembly_code)
-  end
-
-  def test_integration_test_basic_test
-    assembly_code = `bin/vm-translator examples/BasicTest.vm`
-    expected = File.read("test/fixtures/BasicTest.asm")
-    assert_equal(expected, assembly_code)
-  end
-
-  def test_integration_test_pointer_test
-    assembly_code = `bin/vm-translator examples/PointerTest.vm`
-    expected = File.read("test/fixtures/PointerTest.asm")
-    assert_equal(expected, assembly_code)
+    define_method(test_name) do
+      assembly_code = `bin/vm-translator #{file_path}`
+      expected = File.read("test/fixtures/#{file_name}.asm")
+      assert_equal(expected, assembly_code)
+    end
   end
 end

--- a/test/integration/vm_translator_test.rb
+++ b/test/integration/vm_translator_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
 
 class VMTranslatorIntegrationTest < Minitest::Test
-  Dir.glob("examples/**").each do |file_path|
-    file_name = /examples\/(.*).vm/.match(file_path)[1]
-    test_name = "test_integration_#{file_name}"
+  Dir.glob("*.vm", base: "examples").each do |file_name|
+    base_name = File.basename(file_name, ".*")
+    test_name = "test_integration_#{base_name}"
 
     define_method(test_name) do
-      assembly_code = `bin/vm-translator #{file_path}`
-      expected = File.read("test/fixtures/#{file_name}.asm")
+      assembly_code = `bin/vm-translator examples/#{file_name}`
+      expected = File.read("test/fixtures/#{base_name}.asm")
       assert_equal(expected, assembly_code)
     end
   end


### PR DESCRIPTION
Resolves: https://github.com/wildmaples/jack-virtual-machine/issues/8

## Testing

This check doesn't exactly proves that the correct thing is being run but combined with the code change, it does give a better peace of mind. 

```
➜  jack-virtual-machine git:(metaprogram-integration-tests) ✗ ruby -Itest test/integration/vm_translator_test.rb -v
Run options: -v --seed 19022

# Running:

VMTranslatorIntegrationTest#test_integration_StackTest = 0.11 s = .
VMTranslatorIntegrationTest#test_integration_StaticTest = 0.11 s = .
VMTranslatorIntegrationTest#test_integration_BasicTest = 0.11 s = .
VMTranslatorIntegrationTest#test_integration_Push = 0.11 s = .
VMTranslatorIntegrationTest#test_integration_SimpleAdd = 0.11 s = .
VMTranslatorIntegrationTest#test_integration_PointerTest = 0.11 s = .
VMTranslatorIntegrationTest#test_integration_SimpleEq = 0.11 s = .

Finished in 0.761320s, 9.1946 runs/s, 9.1946 assertions/s.

7 runs, 7 assertions, 0 failures, 0 errors, 0 skips
```