### PR TITLE
Implement function calls and bootstrap code

### DIFF
--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -134,7 +134,7 @@ class CodeWriter
 
   def write_call(function_name, num_args)
     @out.puts <<~EOF
-      @$return-address
+      @$return-address#{@label_counter}
       D=A
     EOF
     write_push_D_register
@@ -164,7 +164,7 @@ class CodeWriter
     EOF
 
     write_goto(function_name)
-    write_label("return-address")
+    write_label("return-address#{@label_counter}")
   end
 
   def write_return

--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -108,7 +108,14 @@ class CodeWriter
   end
 
   def write_init
-    raise NotImplementedError
+    @out.puts <<~EOF
+      @256
+      D=A
+      @SP
+      M=D
+    EOF
+
+    write_call("Sys.init", 0)
   end
 
   def write_label(label)

--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -133,7 +133,48 @@ class CodeWriter
   end
 
   def write_call(function_name, num_args)
-    raise NotImplementedError
+    @out.puts <<~EOF
+      @$return-address
+      D=A
+    EOF
+    write_push_D_register
+
+    ["LCL", "ARG", "THIS", "THAT"].each do |label|
+      @out.puts <<~EOF
+        @#{label}
+        D=M
+      EOF
+      write_push_D_register
+    end
+
+    @out.puts <<~EOF
+      @#{num_args + 5}
+      D=A
+      @SP
+      D=M-D
+      @ARG
+      M=D
+    EOF
+
+    @out.puts <<~EOF
+      @SP
+      D=M
+      @LCL
+      M=D
+    EOF
+
+    write_goto(function_name)
+    write_label("return-address")
+  end
+
+  def write_push_D_register
+    @out.puts <<~EOF
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+    EOF
   end
 
   def write_return

--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -167,16 +167,6 @@ class CodeWriter
     write_label("return-address")
   end
 
-  def write_push_D_register
-    @out.puts <<~EOF
-      @SP
-      A=M
-      M=D
-      @SP
-      M=M+1
-    EOF
-  end
-
   def write_return
     @out.puts <<~EOF
       @LCL
@@ -267,5 +257,15 @@ class CodeWriter
     when "static"
       "@#{@file_name}.#{index}\nD=M"
     end
+  end
+
+  def write_push_D_register
+    @out.puts <<~EOF
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+    EOF
   end
 end

--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -25,7 +25,8 @@ class Parser
     'if-goto' => :C_IF,
     'goto' => :C_GOTO,
     'function' => :C_FUNCTION,
-    'return' => :C_RETURN
+    'return' => :C_RETURN,
+    'call' => :C_CALL
   }
 
   def command_type

--- a/lib/vm_translator.rb
+++ b/lib/vm_translator.rb
@@ -31,6 +31,8 @@ class VMTranslator
         code_writer.write_function(parser.arg1, parser.arg2)
       when :C_RETURN
         code_writer.write_return
+      when :C_CALL
+        code_writer.write_call(parser.arg1, parser.arg2)
       else
         warn("Unknown command type passed into VMTranslator")
       end

--- a/test/unit/code_writer_test.rb
+++ b/test/unit/code_writer_test.rb
@@ -2,10 +2,13 @@ require "test_helper"
 require "code_writer"
 
 class CodeWriterTest < Minitest::Test
+  def setup
+    @output = StringIO.new
+    @code_writer = CodeWriter.new(@output)
+  end
+
   def test_write_push_pop_writes_C_PUSH_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_PUSH, "constant", 17)
+    @code_writer.write_push_pop(:C_PUSH, "constant", 17)
     expected = <<~EOF
       @17
       D=A
@@ -16,13 +19,11 @@ class CodeWriterTest < Minitest::Test
       M=M+1
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_PUSH_to_output_999
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_PUSH, "constant", 999)
+    @code_writer.write_push_pop(:C_PUSH, "constant", 999)
     expected = <<~EOF
       @999
       D=A
@@ -33,21 +34,17 @@ class CodeWriterTest < Minitest::Test
       M=M+1
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_close_closes_io
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    refute(output.closed?)
-    code_writer.close
-    assert(output.closed?)
+    refute(@output.closed?)
+    @code_writer.close
+    assert(@output.closed?)
   end
 
   def test_write_arithmetic_add
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("add")
+    @code_writer.write_arithmetic("add")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -56,13 +53,11 @@ class CodeWriterTest < Minitest::Test
       M=M+D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_sub
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("sub")
+    @code_writer.write_arithmetic("sub")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -71,13 +66,11 @@ class CodeWriterTest < Minitest::Test
       M=M-D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_eq
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("eq")
+    @code_writer.write_arithmetic("eq")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -101,14 +94,12 @@ class CodeWriterTest < Minitest::Test
       (END0)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_eq_twice
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("eq")
-    code_writer.write_arithmetic("eq")
+    @code_writer.write_arithmetic("eq")
+    @code_writer.write_arithmetic("eq")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -152,13 +143,11 @@ class CodeWriterTest < Minitest::Test
       (END1)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_lt
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("lt")
+    @code_writer.write_arithmetic("lt")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -182,14 +171,12 @@ class CodeWriterTest < Minitest::Test
       (END0)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_lt_twice
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("lt")
-    code_writer.write_arithmetic("lt")
+    @code_writer.write_arithmetic("lt")
+    @code_writer.write_arithmetic("lt")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -233,13 +220,11 @@ class CodeWriterTest < Minitest::Test
       (END1)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_gt
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("gt")
+    @code_writer.write_arithmetic("gt")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -263,26 +248,22 @@ class CodeWriterTest < Minitest::Test
       (END0)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_neg
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("neg")
+    @code_writer.write_arithmetic("neg")
     expected = <<~EOF
       @SP
       A=M-1
       M=-M
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_and
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("and")
+    @code_writer.write_arithmetic("and")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -291,13 +272,11 @@ class CodeWriterTest < Minitest::Test
       M=M&D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_or
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("or")
+    @code_writer.write_arithmetic("or")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -306,26 +285,22 @@ class CodeWriterTest < Minitest::Test
       M=M|D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_arithmetic_not
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_arithmetic("not")
+    @code_writer.write_arithmetic("not")
     expected = <<~EOF
       @SP
       A=M-1
       M=!M
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_POP_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_POP, "local", 123)
+    @code_writer.write_push_pop(:C_POP, "local", 123)
     expected = <<~EOF
       @SP
       AM=M-1
@@ -346,13 +321,11 @@ class CodeWriterTest < Minitest::Test
       M=D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_POP_argument_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_POP, "argument", 123)
+    @code_writer.write_push_pop(:C_POP, "argument", 123)
     expected = <<~EOF
       @SP
       AM=M-1
@@ -373,13 +346,11 @@ class CodeWriterTest < Minitest::Test
       M=D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_POP_temp_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_POP, "temp", 6)
+    @code_writer.write_push_pop(:C_POP, "temp", 6)
     expected = <<~EOF
       @SP
       AM=M-1
@@ -397,13 +368,11 @@ class CodeWriterTest < Minitest::Test
       M=D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_another_C_POP_temp_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_POP, "temp", 1)
+    @code_writer.write_push_pop(:C_POP, "temp", 1)
     expected = <<~EOF
       @SP
       AM=M-1
@@ -421,13 +390,11 @@ class CodeWriterTest < Minitest::Test
       M=D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_PUSH_local
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_PUSH, "local", 0)
+    @code_writer.write_push_pop(:C_PUSH, "local", 0)
     expected = <<~EOF
       @0
       D=A
@@ -441,13 +408,11 @@ class CodeWriterTest < Minitest::Test
       M=M+1
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_POP_pointer_0_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_POP, "pointer", 0)
+    @code_writer.write_push_pop(:C_POP, "pointer", 0)
     expected = <<~EOF
       @SP
       AM=M-1
@@ -465,13 +430,11 @@ class CodeWriterTest < Minitest::Test
       M=D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_PUSH_pointer
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_push_pop(:C_PUSH, "pointer", 0)
+    @code_writer.write_push_pop(:C_PUSH, "pointer", 0)
     expected = <<~EOF
       @3
       D=M
@@ -482,14 +445,12 @@ class CodeWriterTest < Minitest::Test
       M=M+1
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_POP_static
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.set_file_name("Foo")
-    code_writer.write_push_pop(:C_POP, "static", 8)
+    @code_writer.set_file_name("Foo")
+    @code_writer.write_push_pop(:C_POP, "static", 8)
     expected = <<~EOF
       @SP
       AM=M-1
@@ -507,14 +468,12 @@ class CodeWriterTest < Minitest::Test
       M=D
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_push_pop_writes_C_PUSH_static
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.set_file_name("Bar")
-    code_writer.write_push_pop(:C_PUSH, "static", 8)
+    @code_writer.set_file_name("Bar")
+    @code_writer.write_push_pop(:C_PUSH, "static", 8)
     expected = <<~EOF
       @Bar.8
       D=M
@@ -525,22 +484,18 @@ class CodeWriterTest < Minitest::Test
       M=M+1
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_label_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_label("LOOP_START")
+    @code_writer.write_label("LOOP_START")
     expected = "($LOOP_START)\n"
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_if_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_if("LOOP_START")
+    @code_writer.write_if("LOOP_START")
     expected = <<~EOF
       @SP
       AM=M-1
@@ -549,25 +504,21 @@ class CodeWriterTest < Minitest::Test
       D;JNE
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_goto_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_goto("LOOP_START")
+    @code_writer.write_goto("LOOP_START")
     expected = <<~EOF
       @$LOOP_START
       0;JMP
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_function_writes_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_function("foo", 3)
+    @code_writer.write_function("foo", 3)
     expected = <<~EOF
       (foo)
       @0
@@ -593,13 +544,11 @@ class CodeWriterTest < Minitest::Test
       M=M+1
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_return_writes_to_output
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_return
+    @code_writer.write_return
     expected = <<~EOF
       @LCL
       D=M
@@ -645,13 +594,11 @@ class CodeWriterTest < Minitest::Test
       0;JMP
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_call
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_call("foo", 9)
+    @code_writer.write_call("foo", 9)
 
     expected = <<~EOF
       @$return-address0
@@ -704,13 +651,11 @@ class CodeWriterTest < Minitest::Test
       ($return-address0)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 
   def test_write_init
-    output = StringIO.new
-    code_writer = CodeWriter.new(output)
-    code_writer.write_init
+    @code_writer.write_init
 
     expected = <<~EOF
       @256
@@ -767,6 +712,6 @@ class CodeWriterTest < Minitest::Test
       ($return-address0)
     EOF
 
-    assert_equal(expected, output.string)
+    assert_equal(expected, @output.string)
   end
 end

--- a/test/unit/code_writer_test.rb
+++ b/test/unit/code_writer_test.rb
@@ -654,7 +654,7 @@ class CodeWriterTest < Minitest::Test
     code_writer.write_call("foo", 9)
 
     expected = <<~EOF
-      @$return-address
+      @$return-address0
       D=A
       @SP
       A=M
@@ -701,7 +701,7 @@ class CodeWriterTest < Minitest::Test
       M=D
       @$foo
       0;JMP
-      ($return-address)
+      ($return-address0)
     EOF
 
     assert_equal(expected, output.string)

--- a/test/unit/code_writer_test.rb
+++ b/test/unit/code_writer_test.rb
@@ -647,4 +647,63 @@ class CodeWriterTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_write_call
+    output = StringIO.new
+    code_writer = CodeWriter.new(output)
+    code_writer.write_call("foo", 9)
+
+    expected = <<~EOF
+      @$return-address
+      D=A
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @LCL
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @ARG
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @THIS
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @THAT
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @14
+      D=A
+      @SP
+      D=M-D
+      @ARG
+      M=D
+      @SP
+      D=M
+      @LCL
+      M=D
+      @$foo
+      0;JMP
+      ($return-address)
+    EOF
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/code_writer_test.rb
+++ b/test/unit/code_writer_test.rb
@@ -706,4 +706,67 @@ class CodeWriterTest < Minitest::Test
 
     assert_equal(expected, output.string)
   end
+
+  def test_write_init
+    output = StringIO.new
+    code_writer = CodeWriter.new(output)
+    code_writer.write_init
+
+    expected = <<~EOF
+      @256
+      D=A
+      @SP
+      M=D
+      @$return-address0
+      D=A
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @LCL
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @ARG
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @THIS
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @THAT
+      D=M
+      @SP
+      A=M
+      M=D
+      @SP
+      M=M+1
+      @5
+      D=A
+      @SP
+      D=M-D
+      @ARG
+      M=D
+      @SP
+      D=M
+      @LCL
+      M=D
+      @$Sys.init
+      0;JMP
+      ($return-address0)
+    EOF
+
+    assert_equal(expected, output.string)
+  end
 end

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -178,4 +178,14 @@ class ParserTest < Minitest::Test
     parser.advance
     assert_equal(:C_RETURN, parser.command_type)
   end
+
+  def test_command_type_returns_call_command_and_arg1_arg2
+    input_file = StringIO.new("call foo 3")
+    parser = Parser.new(input_file)
+
+    parser.advance
+    assert_equal(:C_CALL, parser.command_type)
+    assert_equal("foo", parser.arg1)
+    assert_equal(3, parser.arg2)
+  end
 end


### PR DESCRIPTION
## Changes
* Implement `#write_call` and `#write_init` 
* Parse `:C_CALL`
* Some clean up in the test file 

Despite the `VMTranslator` translating function calls, there is no integration test for this change yet. I'll add that change in the next PR.